### PR TITLE
Set inference node in the config example url

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -16,7 +16,7 @@
             "inferenceEntrypointName": "api-worker-reputer",
             "loopSeconds": 5,
             "parameters": {
-                "InferenceEndpoint": "http://source:8000/inference/{Token}",
+                "InferenceEndpoint": "http://inference:8000/inference/{Token}",
                 "Token": "ETH"
             }
         }


### PR DESCRIPTION
- Set `inference` in the config's example url, so it runs out of the box